### PR TITLE
bench: VID ADVZ remaining functions

### DIFF
--- a/benches/advz.rs
+++ b/benches/advz.rs
@@ -115,5 +115,5 @@ fn advz_main(c: &mut Criterion) {
     advz::<Bn254, Sha256>(c, "Bn254");
 }
 
-criterion_group!(benches, advz_main);
+criterion_group!(name = benches; config = Criterion::default().sample_size(10); targets = advz_main);
 criterion_main!(benches);


### PR DESCRIPTION
close #49, #50, #51 

- Follow-up PR for #47 : benches for remaining VID functions `commit`, `verify_share`, `recover`.
- Summary of data collected from my local machine will be posted to the above github issues.