### PR TITLE
perf: VID ADVZ use FFT domain, use FFT in disperse

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Test
         run: |
           cargo test --workspace --no-run
-          cargo test --workspace --verbose -- --report-time
+          cargo test --workspace --verbose
         timeout-minutes: 30
 
       - name: Generate Documentation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Test
         run: |
           cargo test --workspace --no-run
-          cargo test --workspace --verbose -- -Zunstable-options --report-time
+          cargo test --workspace --verbose -- --report-time
         timeout-minutes: 30
 
       - name: Generate Documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,10 @@ digest = { version = "0.10" }
 displaydoc = { version = "0.2.3", default-features = false }
 ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
 generic-array = "0.14.7"
-jf-primitives = { git = "https://github.com/espressosystems/jellyfish" } # , tag = "0.3.0"
-jf-utils = { git = "https://github.com/espressosystems/jellyfish" } # , tag = "0.3.0"
+# jf-primitives = { git = "https://github.com/espressosystems/jellyfish" } # , tag = "0.3.0"
+# jf-utils = { git = "https://github.com/espressosystems/jellyfish" } # , tag = "0.3.0"
+jf-primitives = { path = "../jellyfish/primitives" } # , tag = "0.3.0"
+jf-utils = { path = "../jellyfish/utilities" } # , tag = "0.3.0"
 serde = { version = "1.0", default-features = false, features = ["derive", "rc"] }
 sha3 = "0.10.7"
 tagged-base64 = { git = "https://github.com/espressosystems/tagged-base64", tag = "0.3.0" }
@@ -35,7 +37,8 @@ typenum = { version = "1.16.0" }
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }
-jf-primitives = { git = "https://github.com/espressosystems/jellyfish", features = ["test-srs"] } # , tag = "0.3.0"
+# jf-primitives = { git = "https://github.com/espressosystems/jellyfish", features = ["test-srs"] } # , tag = "0.3.0"
+jf-primitives = { path = "../jellyfish/primitives", features = ["test-srs"] } # , tag = "0.3.0"
 sha2 = { version = "0.10" }
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,8 @@ digest = { version = "0.10" }
 displaydoc = { version = "0.2.3", default-features = false }
 ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
 generic-array = "0.14.7"
-# jf-primitives = { git = "https://github.com/espressosystems/jellyfish" } # , tag = "0.3.0"
-# jf-utils = { git = "https://github.com/espressosystems/jellyfish" } # , tag = "0.3.0"
-jf-primitives = { path = "../jellyfish/primitives" } # , tag = "0.3.0"
-jf-utils = { path = "../jellyfish/utilities" } # , tag = "0.3.0"
+jf-primitives = { git = "https://github.com/espressosystems/jellyfish" }
+jf-utils = { git = "https://github.com/espressosystems/jellyfish" }
 serde = { version = "1.0", default-features = false, features = ["derive", "rc"] }
 sha3 = "0.10.7"
 tagged-base64 = { git = "https://github.com/espressosystems/tagged-base64", tag = "0.3.0" }
@@ -37,8 +35,7 @@ typenum = { version = "1.16.0" }
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }
-# jf-primitives = { git = "https://github.com/espressosystems/jellyfish", features = ["test-srs"] } # , tag = "0.3.0"
-jf-primitives = { path = "../jellyfish/primitives", features = ["test-srs"] } # , tag = "0.3.0"
+jf-primitives = { git = "https://github.com/espressosystems/jellyfish", features = ["test-srs"] }
 sha2 = { version = "0.10" }
 
 [[bench]]

--- a/benches/advz.rs
+++ b/benches/advz.rs
@@ -8,7 +8,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Through
 use digest::{Digest, DynDigest, OutputSizeUser};
 use generic_array::ArrayLength;
 use hotshot_primitives::vid::{advz::Advz, VidScheme};
-use jf_primitives::pcs::{prelude::UnivariateKzgPCS, PolynomialCommitmentScheme};
+use jf_primitives::pcs::{checked_fft_size, prelude::UnivariateKzgPCS, PolynomialCommitmentScheme};
 use sha2::Sha256;
 
 const KB: usize = 1 << 10;
@@ -31,9 +31,11 @@ where
     let supported_degree = poly_degrees_iter.clone().max().unwrap();
     let vid_sizes_iter = poly_degrees_iter.zip(storage_node_counts);
     let mut rng = jf_utils::test_rng();
-    let srs =
-        UnivariateKzgPCS::<E>::gen_srs_for_testing(&mut rng, checked_fft_size(supported_degree))
-            .unwrap();
+    let srs = UnivariateKzgPCS::<E>::gen_srs_for_testing(
+        &mut rng,
+        checked_fft_size(supported_degree).unwrap(),
+    )
+    .unwrap();
 
     // run all benches for each payload_byte_lens
     for len in payload_byte_lens {
@@ -110,16 +112,6 @@ where
             );
         }
         grp.finish();
-    }
-}
-
-// copied from https://github.com/EspressoSystems/jellyfish/blob/466a7604f00a6d5b142ae1b3b7aabcd1111f06df/primitives/src/pcs/mod.rs#L304
-// TODO make this upstream fn public
-fn checked_fft_size(degree: usize) -> usize {
-    if degree.is_power_of_two() {
-        degree.checked_mul(2).unwrap()
-    } else {
-        degree.checked_next_power_of_two().unwrap()
     }
 }
 

--- a/src/vid/advz.rs
+++ b/src/vid/advz.rs
@@ -68,7 +68,8 @@ where
 
 impl<P, T, H, V> GenericAdvz<P, T, H, V>
 where
-    P: PolynomialCommitmentScheme,
+    P: UnivariatePCS,
+    P::Evaluation: FftField,
 {
     /// Return a new instance of `Self`.
     ///
@@ -85,7 +86,7 @@ where
                 payload_chunk_size, num_storage_nodes
             )));
         }
-        let (ck, vk) = P::trim(srs, payload_chunk_size, None)?;
+        let (ck, vk) = P::trim_fft_size(srs, payload_chunk_size)?;
         Ok(Self {
             payload_chunk_size,
             num_storage_nodes,

--- a/src/vid/advz.rs
+++ b/src/vid/advz.rs
@@ -637,24 +637,19 @@ mod tests {
     #[test]
     fn sad_path_verify_share_corrupt_share_and_commit() {
         let (advz, bytes_random) = avdz_init();
-        let (shares, common) = advz.dispersal_data(&bytes_random).unwrap();
+        let (mut shares, mut common) = advz.dispersal_data(&bytes_random).unwrap();
 
-        for mut share in shares {
-            let mut common_missing_items = common.clone();
+        common.poly_commits.pop();
+        shares[0].evals.pop();
 
-            while !common_missing_items.poly_commits.is_empty() {
-                common_missing_items.poly_commits.pop();
-                share.evals.pop();
+        // equal nonzero lengths for common, share
+        advz.verify_share(&shares[0], &common).unwrap().unwrap_err();
 
-                // equal amounts of share evals, common items
-                advz.verify_share(&share, &common_missing_items)
-                    .unwrap()
-                    .unwrap_err();
-            }
+        common.poly_commits.clear();
+        shares[0].evals.clear();
 
-            // ensure we tested the empty shares edge case
-            assert!(share.evals.is_empty() && common_missing_items.poly_commits.is_empty())
-        }
+        // zero length for common, share
+        advz.verify_share(&shares[0], &common).unwrap().unwrap_err();
     }
 
     #[test]

--- a/src/vid/advz.rs
+++ b/src/vid/advz.rs
@@ -702,9 +702,8 @@ mod tests {
             let mut shares_bad_indices = shares.clone();
 
             // permute indices to avoid duplicates and keep them in bounds
-            for i in 0..shares_bad_indices.len() {
-                shares_bad_indices[i].index =
-                    (shares_bad_indices[i].index + 1) % advz.num_storage_nodes;
+            for share in &mut shares_bad_indices {
+                share.index = (share.index + 1) % advz.num_storage_nodes;
             }
 
             let bytes_recovered = advz

--- a/src/vid/advz.rs
+++ b/src/vid/advz.rs
@@ -544,7 +544,7 @@ mod tests {
 
     use ark_bls12_381::Bls12_381;
     use ark_std::{rand::RngCore, vec};
-    use jf_primitives::merkle_tree::hasher::HasherNode;
+    use jf_primitives::{merkle_tree::hasher::HasherNode, pcs::checked_fft_size};
     use sha2::Sha256;
 
     #[test]
@@ -737,8 +737,11 @@ mod tests {
     fn avdz_init() -> (Advz<Bls12_381, Sha256>, Vec<u8>) {
         let (payload_chunk_size, num_storage_nodes) = (3, 5);
         let mut rng = jf_utils::test_rng();
-        let srs = UnivariateKzgPCS::<Bls12_381>::gen_srs_for_testing(&mut rng, payload_chunk_size)
-            .unwrap();
+        let srs = UnivariateKzgPCS::<Bls12_381>::gen_srs_for_testing(
+            &mut rng,
+            checked_fft_size(payload_chunk_size).unwrap(),
+        )
+        .unwrap();
         let advz = Advz::new(payload_chunk_size, num_storage_nodes, srs).unwrap();
 
         let mut bytes_random = vec![0u8; 4000];

--- a/src/vid/advz.rs
+++ b/src/vid/advz.rs
@@ -224,17 +224,10 @@ where
             polynomial_eval(share.evals.iter().map(FieldMultiplier), pseudorandom_scalar);
 
         // prepare eval point for aggregate proof
+        // TODO(Gus) perf: don't re-compute domain elements: https://github.com/EspressoSystems/jellyfish/issues/313
         let domain =
             P::multi_open_rou_eval_domain(self.payload_chunk_size, self.num_storage_nodes)?;
-        // TODO(Gus) perf: `nth` scales linearly with number of storage nodes!
-        // https://github.com/EspressoSystems/jellyfish/issues/313
-        let point = domain.elements().nth(share.index).ok_or_else(|| {
-            anyhow!(
-                "share index {} out of bounds {} was already checked",
-                share.index,
-                domain.size()
-            )
-        })?;
+        let point = domain.element(share.index);
 
         // verify aggregate proof
         Ok(P::verify(

--- a/tests/advz.rs
+++ b/tests/advz.rs
@@ -9,8 +9,18 @@ mod vid;
 
 #[test]
 fn round_trip() {
+    // play with these items
+    let vid_sizes = [(2, 3), (5, 9)];
+    let byte_lens = [2, 16, 32, 47, 48, 49, 64, 100, 400];
+
+    // more items as a function of the above
+    let supported_degree = vid_sizes.iter().max_by_key(|v| v.0).unwrap().0;
     let mut rng = jf_utils::test_rng();
-    let srs = UnivariateKzgPCS::<Bls12_381>::gen_srs_for_testing(&mut rng, 3).unwrap();
+    let srs = UnivariateKzgPCS::<Bls12_381>::gen_srs_for_testing(
+        &mut rng,
+        checked_fft_size(supported_degree),
+    )
+    .unwrap();
 
     println!(
             "modulus byte len: {}",
@@ -22,6 +32,18 @@ fn round_trip() {
         |payload_chunk_size, num_storage_nodes| {
             Advz::<Bls12_381, Sha256>::new(payload_chunk_size, num_storage_nodes, &srs).unwrap()
         },
+        &vid_sizes,
+        &byte_lens,
         &mut rng,
     );
+}
+
+// copied from https://github.com/EspressoSystems/jellyfish/blob/466a7604f00a6d5b142ae1b3b7aabcd1111f06df/primitives/src/pcs/mod.rs#L304
+// TODO make this upstream fn public
+fn checked_fft_size(degree: usize) -> usize {
+    if degree.is_power_of_two() {
+        degree.checked_mul(2).unwrap()
+    } else {
+        degree.checked_next_power_of_two().unwrap()
+    }
 }

--- a/tests/advz.rs
+++ b/tests/advz.rs
@@ -2,7 +2,7 @@ use hotshot_primitives::vid::advz::Advz;
 
 use ark_bls12_381::Bls12_381;
 use ark_ff::{Field, PrimeField};
-use jf_primitives::pcs::{prelude::UnivariateKzgPCS, PolynomialCommitmentScheme};
+use jf_primitives::pcs::{checked_fft_size, prelude::UnivariateKzgPCS, PolynomialCommitmentScheme};
 use sha2::Sha256;
 
 mod vid;
@@ -18,7 +18,7 @@ fn round_trip() {
     let mut rng = jf_utils::test_rng();
     let srs = UnivariateKzgPCS::<Bls12_381>::gen_srs_for_testing(
         &mut rng,
-        checked_fft_size(supported_degree),
+        checked_fft_size(supported_degree).unwrap(),
     )
     .unwrap();
 
@@ -36,14 +36,4 @@ fn round_trip() {
         &byte_lens,
         &mut rng,
     );
-}
-
-// copied from https://github.com/EspressoSystems/jellyfish/blob/466a7604f00a6d5b142ae1b3b7aabcd1111f06df/primitives/src/pcs/mod.rs#L304
-// TODO make this upstream fn public
-fn checked_fft_size(degree: usize) -> usize {
-    if degree.is_power_of_two() {
-        degree.checked_mul(2).unwrap()
-    } else {
-        degree.checked_next_power_of_two().unwrap()
-    }
 }

--- a/tests/vid/mod.rs
+++ b/tests/vid/mod.rs
@@ -36,28 +36,28 @@ where
             // sample a random subset of shares with size payload_chunk_size
             shares.shuffle(rng);
 
-            // // give minimum number of shares for recovery
-            // let bytes_recovered = vid
-            //     .recover_payload(&shares[..payload_chunk_size], &common)
-            //     .unwrap();
-            // assert_eq!(bytes_recovered, bytes_random);
+            // give minimum number of shares for recovery
+            let bytes_recovered = vid
+                .recover_payload(&shares[..payload_chunk_size], &common)
+                .unwrap();
+            assert_eq!(bytes_recovered, bytes_random);
 
-            // // give an intermediate number of shares for recovery
-            // let intermediate_num_shares = (payload_chunk_size + num_storage_nodes) / 2;
-            // let bytes_recovered = vid
-            //     .recover_payload(&shares[..intermediate_num_shares], &common)
-            //     .unwrap();
-            // assert_eq!(bytes_recovered, bytes_random);
+            // give an intermediate number of shares for recovery
+            let intermediate_num_shares = (payload_chunk_size + num_storage_nodes) / 2;
+            let bytes_recovered = vid
+                .recover_payload(&shares[..intermediate_num_shares], &common)
+                .unwrap();
+            assert_eq!(bytes_recovered, bytes_random);
 
-            // // give all shares for recovery
-            // let bytes_recovered = vid.recover_payload(&shares, &common).unwrap();
-            // assert_eq!(bytes_recovered, bytes_random);
+            // give all shares for recovery
+            let bytes_recovered = vid.recover_payload(&shares, &common).unwrap();
+            assert_eq!(bytes_recovered, bytes_random);
 
-            // // give insufficient shares for recovery
-            // assert_arg_err(
-            //     vid.recover_payload(&shares[..payload_chunk_size - 1], &common),
-            //     "insufficient shares should be arg error",
-            // );
+            // give insufficient shares for recovery
+            assert_arg_err(
+                vid.recover_payload(&shares[..payload_chunk_size - 1], &common),
+                "insufficient shares should be arg error",
+            );
         }
     }
 }

--- a/tests/vid/mod.rs
+++ b/tests/vid/mod.rs
@@ -6,18 +6,19 @@ use ark_std::{
     vec,
 };
 
-pub fn round_trip<V, R>(vid_factory: impl Fn(usize, usize) -> V, rng: &mut R)
-where
+pub fn round_trip<V, R>(
+    vid_factory: impl Fn(usize, usize) -> V,
+    vid_sizes: &[(usize, usize)],
+    payload_byte_lens: &[usize],
+    rng: &mut R,
+) where
     V: VidScheme,
     R: RngCore + CryptoRng,
 {
-    let vid_sizes = [(2, 3), (3, 9)];
-    let byte_lens = [2, 16, 32, 47, 48, 49, 64, 100, 400];
-
-    for (payload_chunk_size, num_storage_nodes) in vid_sizes {
+    for &(payload_chunk_size, num_storage_nodes) in vid_sizes {
         let vid = vid_factory(payload_chunk_size, num_storage_nodes);
 
-        for len in byte_lens {
+        for &len in payload_byte_lens {
             println!(
                 "m: {} n: {} byte_len: {}",
                 payload_chunk_size, num_storage_nodes, len

--- a/tests/vid/mod.rs
+++ b/tests/vid/mod.rs
@@ -36,28 +36,28 @@ where
             // sample a random subset of shares with size payload_chunk_size
             shares.shuffle(rng);
 
-            // give minimum number of shares for recovery
-            let bytes_recovered = vid
-                .recover_payload(&shares[..payload_chunk_size], &common)
-                .unwrap();
-            assert_eq!(bytes_recovered, bytes_random);
+            // // give minimum number of shares for recovery
+            // let bytes_recovered = vid
+            //     .recover_payload(&shares[..payload_chunk_size], &common)
+            //     .unwrap();
+            // assert_eq!(bytes_recovered, bytes_random);
 
-            // give an intermediate number of shares for recovery
-            let intermediate_num_shares = (payload_chunk_size + num_storage_nodes) / 2;
-            let bytes_recovered = vid
-                .recover_payload(&shares[..intermediate_num_shares], &common)
-                .unwrap();
-            assert_eq!(bytes_recovered, bytes_random);
+            // // give an intermediate number of shares for recovery
+            // let intermediate_num_shares = (payload_chunk_size + num_storage_nodes) / 2;
+            // let bytes_recovered = vid
+            //     .recover_payload(&shares[..intermediate_num_shares], &common)
+            //     .unwrap();
+            // assert_eq!(bytes_recovered, bytes_random);
 
-            // give all shares for recovery
-            let bytes_recovered = vid.recover_payload(&shares, &common).unwrap();
-            assert_eq!(bytes_recovered, bytes_random);
+            // // give all shares for recovery
+            // let bytes_recovered = vid.recover_payload(&shares, &common).unwrap();
+            // assert_eq!(bytes_recovered, bytes_random);
 
-            // give insufficient shares for recovery
-            assert_arg_err(
-                vid.recover_payload(&shares[..payload_chunk_size - 1], &common),
-                "insufficient shares should be arg error",
-            );
+            // // give insufficient shares for recovery
+            // assert_arg_err(
+            //     vid.recover_payload(&shares[..payload_chunk_size - 1], &common),
+            //     "insufficient shares should be arg error",
+            // );
         }
     }
 }

--- a/tests/vid/mod.rs
+++ b/tests/vid/mod.rs
@@ -6,6 +6,11 @@ use ark_std::{
     vec,
 };
 
+/// Correctness test generic over anything that impls [`VidScheme`]
+///
+/// `pub` visibility, but it's not part of this crate's public API
+/// because it's in an integration test.
+/// <https://doc.rust-lang.org/book/ch11-03-test-organization.html#submodules-in-integration-tests>
 pub fn round_trip<V, R>(
     vid_factory: impl Fn(usize, usize) -> V,
     vid_sizes: &[(usize, usize)],


### PR DESCRIPTION
close #19 

- Use FFT domain points instead of `1..num_storage_nodes`.
- Use FFT for dispersal via `multi_open_*`.
- Recovery still uses quadratic-time Lagrange interpolation. But now that we use FFT domain any remaining work to use FFT-based interpolation is purely an upstream implementation detail.