### PR TITLE
Refactor QC traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/EspressoSystems/hotshot-primitives"
 
 [dependencies]
 anyhow = "1.0"
-ark-bls12-381 = "0.4.0"
 ark-bls12-377 = "0.4.0"
+ark-bls12-381 = "0.4.0"
 ark-bn254 = "0.4.0"
 ark-ec = "0.4.0"
 ark-ff = "0.4.0"
@@ -26,9 +26,9 @@ digest = { version = "0.10" }
 displaydoc = { version = "0.2.3", default-features = false }
 ethereum-types = { version = "0.14.1", features = ["impl-serde"] }
 generic-array = "0.14.7"
-jf-relation = { git = "https://github.com/espressosystems/jellyfish"}
-jf-primitives = { git = "https://github.com/espressosystems/jellyfish"}
-jf-utils = { git = "https://github.com/espressosystems/jellyfish"}
+jf-primitives = { git = "https://github.com/espressosystems/jellyfish" }
+jf-relation = { git = "https://github.com/espressosystems/jellyfish" }
+jf-utils = { git = "https://github.com/espressosystems/jellyfish" }
 serde = { version = "1.0", default-features = false, features = ["derive", "rc"] }
 sha3 = "0.10.7"
 tagged-base64 = { git = "https://github.com/espressosystems/tagged-base64", tag = "0.3.0" }
@@ -36,8 +36,8 @@ thiserror = "1.0"
 typenum = { version = "1.16.0" }
 
 [dev-dependencies]
-jf-primitives = { git = "https://github.com/espressosystems/jellyfish", features = ["test-srs"]}
 criterion = { version = "0.5.1", features = ["html_reports"] }
+jf-primitives = { git = "https://github.com/espressosystems/jellyfish", features = ["test-srs"] }
 sha2 = { version = "0.10" }
 
 [[bench]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 // #![warn(missing_docs)] // TODO need rustdoc for stake_table
 
 pub mod circuit;
-pub mod quorum_certificate;
+pub mod qc;
 pub mod stake_table;
 pub mod vdf;
 pub mod vid;

--- a/src/qc.rs
+++ b/src/qc.rs
@@ -1,6 +1,9 @@
 //! Quorum Certificate traits and implementations.
 
-use ark_std::rand::{CryptoRng, RngCore};
+use ark_std::{
+    rand::{CryptoRng, RngCore},
+    vec::Vec,
+};
 use bitvec::prelude::*;
 use generic_array::{ArrayLength, GenericArray};
 use jf_primitives::errors::PrimitivesError;
@@ -61,8 +64,15 @@ pub trait QuorumCertificate<A: AggregateableSignatureSchemes + Serialize + for<'
     /// * `qc` - quroum certificate
     /// * `returns` - nothing if the signature is valid, an error otherwise.
     fn check(
-        qc_pp: &Self::QCVerifierParams,
+        qc_vp: &Self::QCVerifierParams,
         message: &GenericArray<A::MessageUnit, Self::MessageLength>,
         qc: &Self::QC,
     ) -> Result<Self::CheckedType, PrimitivesError>;
+
+    /// Trace the list of signers given a qc.
+    fn trace(
+        qc_vp: &Self::QCVerifierParams,
+        message: &GenericArray<A::MessageUnit, Self::MessageLength>,
+        qc: &Self::QC,
+    ) -> Result<Vec<A::VerificationKey>, PrimitivesError>;
 }

--- a/src/qc.rs
+++ b/src/qc.rs
@@ -10,9 +10,7 @@ use serde::{Deserialize, Serialize};
 pub mod bit_vector;
 
 /// Trait for validating a QC built from different signatures on the same message
-pub trait QuorumCertificateValidation<
-    A: AggregateableSignatureSchemes + Serialize + for<'a> Deserialize<'a>,
->
+pub trait QuorumCertificate<A: AggregateableSignatureSchemes + Serialize + for<'a> Deserialize<'a>>
 {
     /// Public parameters for generating the QC
     /// E.g: snark proving/verifying keys, list of (or pointer to) public keys stored in the smart contract.
@@ -22,12 +20,11 @@ pub trait QuorumCertificateValidation<
     /// E.g: verifying keys, stake table commitment
     type QCVerifierParams: Serialize + for<'a> Deserialize<'a>;
 
-    /// Extra value to check the aggregated signature of the QC
-    /// E.g: snark proof, bitmap corresponding to the public keys involved in signing
-    type Proof: Serialize + for<'a> Deserialize<'a>;
-
     /// Allows to fix the size of the message at compilation time.
     type MessageLength: ArrayLength<A::MessageUnit>;
+
+    /// Type of the actual quorum certificate object
+    type QC;
 
     /// Type of some auxiliary information returned by the check function in order to feed oth
     type CheckedType;
@@ -36,38 +33,36 @@ pub trait QuorumCertificateValidation<
     /// NOTE: the original message (vote) should be prefixed with the hash of the stake table.
     /// * `agg_sig_pp` - public parameters for aggregate signature
     /// * `message` - message to be signed
-    /// * `signing_keys` - user signing key
+    /// * `sk` - user signing key
     /// * `returns` - a "simple" signature
-    fn partial_sign<R: CryptoRng + RngCore>(
+    fn sign<R: CryptoRng + RngCore>(
         agg_sig_pp: &A::PublicParameter,
         message: &GenericArray<A::MessageUnit, Self::MessageLength>,
-        sig_key: &A::SigningKey,
+        sk: &A::SigningKey,
         prng: &mut R,
     ) -> Result<A::Signature, PrimitivesError>;
 
     /// Computes an aggregated signature from a set of partial signatures and the verification keys involved
     /// * `qc_pp` - public parameters for generating the QC
-    /// * `active_keys` - a bool vector indicating the list of verification keys corresponding to the set of partial signatures
-    /// * `partial_sigs` - partial signatures on the same message
+    /// * `signers` - a bool vector indicating the list of verification keys corresponding to the set of partial signatures
+    /// * `sigs` - partial signatures on the same message
     /// * `returns` - an error if some of the partial signatures provided are invalid
     ///     or the number of partial signatures / verifications keys are different.
-    ///     Otherwise return an aggregated signature with a proof.
+    ///     Otherwise return an obtained quorum certificate.
     fn assemble(
         qc_pp: &Self::QCProverParams,
-        active_keys: &BitSlice,
-        partial_sigs: &[A::Signature],
-    ) -> Result<(A::Signature, Self::Proof), PrimitivesError>;
+        signers: &BitSlice,
+        sigs: &[A::Signature],
+    ) -> Result<Self::QC, PrimitivesError>;
 
     /// Checks an aggregated signature over some message provided as input
     /// * `qc_vp` - public parameters for validating the QC
     /// * `message` - message to check the aggregated signature against
-    /// * `sig` - aggregated signature on message
-    /// * `proof` - auxiliary information to check the signature
+    /// * `qc` - quroum certificate
     /// * `returns` - nothing if the signature is valid, an error otherwise.
     fn check(
         qc_pp: &Self::QCVerifierParams,
         message: &GenericArray<A::MessageUnit, Self::MessageLength>,
-        sig: &A::Signature,
-        proof: &Self::Proof,
+        qc: &Self::QC,
     ) -> Result<Self::CheckedType, PrimitivesError>;
 }

--- a/src/qc.rs
+++ b/src/qc.rs
@@ -29,9 +29,6 @@ pub trait QuorumCertificate<A: AggregateableSignatureSchemes + Serialize + for<'
     /// Type of the actual quorum certificate object
     type QC;
 
-    /// Type of some auxiliary information returned by the check function in order to feed oth
-    type CheckedType;
-
     /// Produces a partial signature on a message with a single user signing key
     /// NOTE: the original message (vote) should be prefixed with the hash of the stake table.
     /// * `agg_sig_pp` - public parameters for aggregate signature
@@ -67,7 +64,7 @@ pub trait QuorumCertificate<A: AggregateableSignatureSchemes + Serialize + for<'
         qc_vp: &Self::QCVerifierParams,
         message: &GenericArray<A::MessageUnit, Self::MessageLength>,
         qc: &Self::QC,
-    ) -> Result<Self::CheckedType, PrimitivesError>;
+    ) -> Result<(), PrimitivesError>;
 
     /// Trace the list of signers given a qc.
     fn trace(

--- a/src/qc.rs
+++ b/src/qc.rs
@@ -1,0 +1,73 @@
+//! Quorum Certificate traits and implementations.
+
+use ark_std::rand::{CryptoRng, RngCore};
+use bitvec::prelude::*;
+use generic_array::{ArrayLength, GenericArray};
+use jf_primitives::errors::PrimitivesError;
+use jf_primitives::signatures::AggregateableSignatureSchemes;
+use serde::{Deserialize, Serialize};
+
+pub mod bit_vector;
+
+/// Trait for validating a QC built from different signatures on the same message
+pub trait QuorumCertificateValidation<
+    A: AggregateableSignatureSchemes + Serialize + for<'a> Deserialize<'a>,
+>
+{
+    /// Public parameters for generating the QC
+    /// E.g: snark proving/verifying keys, list of (or pointer to) public keys stored in the smart contract.
+    type QCProverParams: Serialize + for<'a> Deserialize<'a>;
+
+    /// Public parameters for validating the QC
+    /// E.g: verifying keys, stake table commitment
+    type QCVerifierParams: Serialize + for<'a> Deserialize<'a>;
+
+    /// Extra value to check the aggregated signature of the QC
+    /// E.g: snark proof, bitmap corresponding to the public keys involved in signing
+    type Proof: Serialize + for<'a> Deserialize<'a>;
+
+    /// Allows to fix the size of the message at compilation time.
+    type MessageLength: ArrayLength<A::MessageUnit>;
+
+    /// Type of some auxiliary information returned by the check function in order to feed oth
+    type CheckedType;
+
+    /// Produces a partial signature on a message with a single user signing key
+    /// NOTE: the original message (vote) should be prefixed with the hash of the stake table.
+    /// * `agg_sig_pp` - public parameters for aggregate signature
+    /// * `message` - message to be signed
+    /// * `signing_keys` - user signing key
+    /// * `returns` - a "simple" signature
+    fn partial_sign<R: CryptoRng + RngCore>(
+        agg_sig_pp: &A::PublicParameter,
+        message: &GenericArray<A::MessageUnit, Self::MessageLength>,
+        sig_key: &A::SigningKey,
+        prng: &mut R,
+    ) -> Result<A::Signature, PrimitivesError>;
+
+    /// Computes an aggregated signature from a set of partial signatures and the verification keys involved
+    /// * `qc_pp` - public parameters for generating the QC
+    /// * `active_keys` - a bool vector indicating the list of verification keys corresponding to the set of partial signatures
+    /// * `partial_sigs` - partial signatures on the same message
+    /// * `returns` - an error if some of the partial signatures provided are invalid
+    ///     or the number of partial signatures / verifications keys are different.
+    ///     Otherwise return an aggregated signature with a proof.
+    fn assemble(
+        qc_pp: &Self::QCProverParams,
+        active_keys: &BitSlice,
+        partial_sigs: &[A::Signature],
+    ) -> Result<(A::Signature, Self::Proof), PrimitivesError>;
+
+    /// Checks an aggregated signature over some message provided as input
+    /// * `qc_vp` - public parameters for validating the QC
+    /// * `message` - message to check the aggregated signature against
+    /// * `sig` - aggregated signature on message
+    /// * `proof` - auxiliary information to check the signature
+    /// * `returns` - nothing if the signature is valid, an error otherwise.
+    fn check(
+        qc_pp: &Self::QCVerifierParams,
+        message: &GenericArray<A::MessageUnit, Self::MessageLength>,
+        sig: &A::Signature,
+        proof: &Self::Proof,
+    ) -> Result<Self::CheckedType, PrimitivesError>;
+}

--- a/src/qc/bit_vector.rs
+++ b/src/qc/bit_vector.rs
@@ -1,83 +1,23 @@
-use ark_std::fmt::Debug;
-use bitvec::prelude::*;
-use core::marker::PhantomData;
-use typenum::U32;
+//! Implementation for BitVectorQC that uses BLS signature + Bit vector.
+//! See more details in HotShot paper.
 
+use crate::qc::QuorumCertificateValidation;
 use ark_std::{
+    fmt::Debug,
     format,
+    marker::PhantomData,
     rand::{CryptoRng, RngCore},
     vec,
     vec::Vec,
 };
+use bitvec::prelude::*;
 use ethereum_types::U256;
-use generic_array::{ArrayLength, GenericArray};
+use generic_array::GenericArray;
 use jf_primitives::errors::PrimitivesError;
 use jf_primitives::errors::PrimitivesError::ParameterError;
 use jf_primitives::signatures::AggregateableSignatureSchemes;
 use serde::{Deserialize, Serialize};
-
-/// Trait for validating a QC built from different signatures on the same message
-pub trait QuorumCertificateValidation<
-    A: AggregateableSignatureSchemes + Serialize + for<'a> Deserialize<'a>,
->
-{
-    /// Public parameters for generating the QC
-    /// E.g: snark proving/verifying keys, list of (or pointer to) public keys stored in the smart contract.
-    type QCProverParams: Serialize + for<'a> Deserialize<'a>;
-
-    /// Public parameters for validating the QC
-    /// E.g: verifying keys, stake table commitment
-    type QCVerifierParams: Serialize + for<'a> Deserialize<'a>;
-
-    /// Extra value to check the aggregated signature of the QC
-    /// E.g: snark proof, bitmap corresponding to the public keys involved in signing
-    type Proof: Serialize + for<'a> Deserialize<'a>;
-
-    /// Allows to fix the size of the message at compilation time.
-    type MessageLength: ArrayLength<A::MessageUnit>;
-
-    /// Type of some auxiliary information returned by te check function in order to feed oth
-    type CheckedType;
-
-    /// Produces a partial signature on a message with a single user signing key
-    /// NOTE: the original message (vote) should be prefixed with the hash of the stake table.
-    /// * `agg_sig_pp` - public parameters for aggregate signature
-    /// * `message` - message to be signed
-    /// * `signing_keys` - user signing key
-    /// * `returns` - a "simple" signature
-    fn partial_sign<R: CryptoRng + RngCore>(
-        agg_sig_pp: &A::PublicParameter,
-        message: &GenericArray<A::MessageUnit, Self::MessageLength>,
-        sig_key: &A::SigningKey,
-        prng: &mut R,
-    ) -> Result<A::Signature, PrimitivesError>;
-
-    /// Computes an aggregated signature from a set of partial signatures and the verification keys involved
-    /// * `qc_pp` - public parameters for generating the QC
-    /// * `active_keys` - a bool vector indicating the list of verification keys corresponding to the set of partial signatures
-    /// * `partial_sigs` - partial signatures on the same message
-    /// * `returns` - an error if some of the partial signatures provided are invalid
-    ///     or the number of partial signatures / verifications keys are different.
-    ///     Otherwise return an aggregated signature with a proof.
-    fn assemble(
-        qc_pp: &Self::QCProverParams,
-        active_keys: &BitSlice,
-        partial_sigs: &[A::Signature],
-    ) -> Result<(A::Signature, Self::Proof), PrimitivesError>;
-
-    /// Checks an aggregated signature over some message provided as input
-    /// * `qc_vp` - public parameters for validating the QC
-    /// * `message` - message to check the aggregated signature against
-    /// * `sig` - aggregated signature on message
-    /// * `proof` - auxiliary information to check the signature
-    /// * `returns` - nothing if the signature is valid, an error otherwise.
-    fn check(
-        qc_pp: &Self::QCVerifierParams,
-        message: &GenericArray<A::MessageUnit, Self::MessageLength>,
-        sig: &A::Signature,
-        proof: &Self::Proof,
-    ) -> Result<Self::CheckedType, PrimitivesError>;
-}
+use typenum::U32;
 
 #[derive(Serialize, Deserialize)]
 pub struct BitvectorQuorumCertificate<

--- a/src/qc/bit_vector.rs
+++ b/src/qc/bit_vector.rs
@@ -49,7 +49,6 @@ where
 
     type QC = (A::Signature, BitVec);
     type MessageLength = U32;
-    type CheckedType = ();
 
     fn sign<R: CryptoRng + RngCore>(
         agg_sig_pp: &A::PublicParameter,
@@ -112,7 +111,7 @@ where
         qc_vp: &Self::QCVerifierParams,
         message: &GenericArray<A::MessageUnit, Self::MessageLength>,
         qc: &Self::QC,
-    ) -> Result<Self::CheckedType, PrimitivesError> {
+    ) -> Result<(), PrimitivesError> {
         let (sig, signers) = qc;
         if signers.len() != qc_vp.stake_entries.len() {
             return Err(ParameterError(format!(


### PR DESCRIPTION
Changes include:

- Renaming: 
  - `trait QuorumCertificateValidation` -> `trait QuorumCertificate`
  - `struct BitvectorQuorumCertificate` -> `struct BitVectorQC`
  - `::parti_sign()` -> `::sign()` (consistent with hotshot spec)
  - `active_keys` -> `signers`
- Trait refactor
  - removed associated type `CheckedType` as @nyospe pointed out that we don't need this. 
  - removed associated type `Proof`, and replace with `QC`
  - update `assemble()` and `check()` to deal with `Self::QC` directly (consistent with Hotshot spec)
  - add `trace()` API and tests